### PR TITLE
Fix bug in bestAvailableCell function.

### DIFF
--- a/js/grid.js
+++ b/js/grid.js
@@ -55,7 +55,7 @@ Grid.prototype.bestAvailaibleCell = function () {
   if (indices_weighted.length)
     return cells[indices_weighted[Math.floor(Math.random() * indices_weighted.length)]];
   else
-    return cells[0];
+    return cells[Math.floor(Math.random() * cells.length)];
 };
 
 Grid.prototype.availableCells = function () {


### PR DESCRIPTION
The bestAvailableCell function was returning cell[0] if no cell has 2s adjacent to it. This commit fixes this issue by returning a random cell if this happens.
